### PR TITLE
use pd-ssd; larger disk size for throughput

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,12 +52,12 @@ Let's create a storage class to use named something like `m3-cluster-storage-cla
 kind: StorageClass
 apiVersion: storage.k8s.io/v1
 metadata:
-  name: topology-aware-standard
+  name: topology-aware-ssd
 provisioner: kubernetes.io/gce-pd
 # WaitForFirstConsumer required with k8s 1.12 
 volumeBindingMode: WaitForFirstConsumer
 parameters:
-  type: pd-standard
+  type: pd-ssd
 ```
 
 Now apply:
@@ -129,12 +129,12 @@ spec:
       name: m3db-data
     spec:
       # Note: using the storage class we created
-      storageClassName: topology-aware-standard
+      storageClassName: topology-aware-ssd
       accessModes:
       - ReadWriteOnce
       resources:
         requests:
-          storage: 100Gi
+          storage: 500Gi
 ```
 
 Apply the manifest:

--- a/examples/m3-cluster-eu-spec.yml
+++ b/examples/m3-cluster-eu-spec.yml
@@ -54,9 +54,9 @@ spec:
     metadata:
       name: m3db-data
     spec:
-      storageClassName: topology-aware-standard
+      storageClassName: topology-aware-ssd
       accessModes:
       - ReadWriteOnce
       resources:
         requests:
-          storage: 100Gi
+          storage: 500Gi

--- a/examples/m3-cluster-storage-class.yml
+++ b/examples/m3-cluster-storage-class.yml
@@ -1,9 +1,9 @@
 kind: StorageClass
 apiVersion: storage.k8s.io/v1
 metadata:
-  name: topology-aware-standard
+  name: topology-aware-ssd
 provisioner: kubernetes.io/gce-pd
 # WaitForFirstConsumer required with k8s 1.12 
 volumeBindingMode: WaitForFirstConsumer
 parameters:
-  type: pd-standard
+  type: pd-ssd

--- a/examples/m3-cluster-us-spec.yml
+++ b/examples/m3-cluster-us-spec.yml
@@ -54,9 +54,9 @@ spec:
     metadata:
       name: m3db-data
     spec:
-      storageClassName: topology-aware-standard
+      storageClassName: topology-aware-ssd
       accessModes:
       - ReadWriteOnce
       resources:
         requests:
-          storage: 100Gi
+          storage: 500Gi


### PR DESCRIPTION
Want faster disks for benchmarking.

GCP limits throughput based on size of the disk. 500gb seems to be a
good tradeoff, 1TB would allow to max out on write throughput. Search
"To improve SSD persistent disk performance on your existing instances"
on this page for more details:
https://cloud.google.com/compute/docs/disks/performance#size_price_performance.